### PR TITLE
ZeroMQServer init bug

### DIFF
--- a/simpleRaft/servers/server.py
+++ b/simpleRaft/servers/server.py
@@ -44,7 +44,7 @@ class Server(object):
 
 class ZeroMQServer(Server):
     def __init__(self, name, state, log, messageBoard, neighbors, port=6666):
-        super(Server, self).__init__(name, state, log, messageBoard, neighbors)
+        super(ZeroMQServer, self).__init__(name, state, log, messageBoard, neighbors)
         self._port = 6666
 
         class SubscribeThread(threading.Thread):


### PR DESCRIPTION
Calling super(Server, self).**init**(...) was calling object.**init**()
